### PR TITLE
Prevent likes_count tampering via PUT/PATCH

### DIFF
--- a/app/models/card.py
+++ b/app/models/card.py
@@ -44,5 +44,3 @@ class Card(db.Model):
     def update_from_dict(self, dict_data_card):
         if "message" in dict_data_card:
             self.message = dict_data_card["message"]
-        if "likes_count" in dict_data_card:
-            self.likes_count = dict_data_card["likes_count"]

--- a/tests/test_card_model.py
+++ b/tests/test_card_model.py
@@ -63,4 +63,4 @@ def test_update_card_from_dict(app):
 
     # Assert
     assert card.message == "New message"
-    assert card.likes_count == 5
+    assert card.likes_count == 0

--- a/tests/test_card_routes.py
+++ b/tests/test_card_routes.py
@@ -25,6 +25,25 @@ def test_put_card(client, one_card):
     # Assert
     assert response.status_code == 204
 
+# checks likes_count cannot be changed by PUT /cards/<card_id>
+def test_put_card_does_not_update_likes_count(client, one_card):
+    # Arrange
+    card_id = one_card.id
+    original_likes = one_card.likes_count
+
+    # Act
+    # Ignores likes_count update attempt
+    update_data = {"message": "Updated Message", "likes_count": 99}
+    response = client.put(f"/cards/{card_id}", json=update_data)
+    assert response.status_code == 204
+
+    # Assert
+    # Refetch and check likes_count to original number
+    response = client.get(f"/cards/{card_id}")
+    data = response.get_json()
+    assert data["cards"]["likes_count"] == original_likes
+
+
 # checks DELETE /cards/<card_id> deletes the card
 def test_delete_card(client, one_card):
     # Arrange


### PR DESCRIPTION
- Updated the card model so likes_count can't be changed through PUT
- Only the PATCH /like endpoint increments likes
- Added test to confirm likes_count stays the same if someone tries to update it directly
- All backend tests passing locally